### PR TITLE
Deploy Message

### DIFF
--- a/.github/workflows/github-notify-slack.yml
+++ b/.github/workflows/github-notify-slack.yml
@@ -23,6 +23,6 @@ jobs:
           SLACK_ICON_EMOJI: ":mega:"
           #SLACK_COLOR: "#EEEEEE"
           SLACK_MESSAGE: ${{ github.event.pull_request.body }}
-          SLACK_TITLE: "New Code Deployed to BETA"
+          SLACK_TITLE: "New Code Deployed"
           SLACK_FOOTER: "Powered By MOF GitHub Actions Library"
-          MSG_MINIMAL: ref,event,commit
+          MSG_MINIMAL: ref,commit


### PR DESCRIPTION
Updated the message that gets displayed within Slack upon a successful merging into beta or master.  The message now reads:

**New Code Deployed**

I also removed the _event_ from being displayed, as this action ONLY runs on successfully merged pull requests.

Now, the Slack Notification message will contain the following:

- developer of the initial commit
- link to the commit within GitHub
- ref (i.e. the branch the commit was successfully merged into - either **beta** or **master**)
- shows actual commit message